### PR TITLE
Corrected error which made asset copying behave incorrectly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM node:8
 RUN mkdir app
 COPY ./heroku_docker .
 RUN yarn install
-COPY ./dist/* ./app/
+COPY ./dist ./app
 CMD yarn start


### PR DESCRIPTION
Assets were not copied correctly to the Docker image, which resulted in files from subdirectories in `assets/` not resolving correctly.