### PR TITLE
loading-screen. Fix disabled tests and add some comments

### DIFF
--- a/__tests__/actions/contextActions.test.js
+++ b/__tests__/actions/contextActions.test.js
@@ -1,4 +1,5 @@
 import { setCategoryAction, setPlaceAction } from "../../src/actions/contextActions";
+import { SET_CATEGORY, SET_PLACE } from "../../src/constants/actions";
 
 // we mock the service so that we can return custom data
 jest.mock("../../src/service", () => {
@@ -27,12 +28,11 @@ describe('contextActions', () => {
         const mockDispatch = jest.fn();
         await action(mockDispatch);
 
-        // FIXME
         expect(mockDispatch).toHaveBeenCalledTimes(4);
-        // expect(mockDispatch.mock.calls[0][0]).toEqual({
-        //     type: SET_CATEGORY,
-        //     payload: [{ id: 65336, }],
-        // });
+        expect(mockDispatch.mock.calls[2][0]).toEqual({
+            type: SET_CATEGORY,
+            payload: [{ id: 65336 }],
+        });
     });
 
     it('should get the place and set the first one of them', async () => {
@@ -40,10 +40,11 @@ describe('contextActions', () => {
         const mockDispatch = jest.fn();
         await action(mockDispatch);
 
+        // Here we could also test that the loading states are dispatched correctly
         expect(mockDispatch).toHaveBeenCalledTimes(3);
-        // expect(mockDispatch.mock.calls[0][0]).toEqual({
-        //     type: SET_PLACE,
-        //     payload: [{ id: 1234 }],
-        // });
+        expect(mockDispatch.mock.calls[1][0]).toEqual({
+            type: SET_PLACE,
+            payload: [{ id: 1234 }],
+        });
     });
 });

--- a/__tests__/actions/questionActions.test.js
+++ b/__tests__/actions/questionActions.test.js
@@ -1,4 +1,5 @@
 import { setQuestionsAction } from "../../src/actions/questionActions";
+import { SET_QUESTIONS } from "../../src/constants/actions";
 //import { SET_QUESTIONS } from "../../src/constants/actions";
 
 // we mock the service so that we can return custom data
@@ -41,24 +42,24 @@ describe("questionActions", () => {
         });
         await action(mockDispatch, mockGetState);
 
-        // TODO: fix test, because of loading states this is now fucking up
+        // here we could also test that the loading states are dispatched correctly
         expect(mockDispatch).toHaveBeenCalledTimes(3);
-        // expect(mockDispatch.mock.calls[0][0]).toEqual({
-        //     type: SET_QUESTIONS,
-        //     payload: [
-        //         {
-        //             id: 1,
-        //             position: 1,
-        //         },
-        //         {
-        //             id: 2,
-        //             position: 2,
-        //         },
-        //         {
-        //             id: 3,
-        //             position: 3,
-        //         },
-        //     ],
-        // });
+        expect(mockDispatch.mock.calls[1][0]).toEqual({
+            type: SET_QUESTIONS,
+            payload: [
+                {
+                    id: 1,
+                    position: 1,
+                },
+                {
+                    id: 2,
+                    position: 2,
+                },
+                {
+                    id: 3,
+                    position: 3,
+                },
+            ],
+        });
     });
 });


### PR DESCRIPTION
`jest.fn()` creates a mock function that allows to track how many times it has been called and with what parameters. In this PR I changed the statement `mockDispatch.mock.calls[0][0]`to `mockDispatch.mock.calls[1][0]`. `calls[1]` means the second call of this function, and `calls[1][0]` means the second call's first argument.