### PR TITLE
Change language bug. Fix failure in changing language caused by trans…

### DIFF
--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -1,10 +1,10 @@
 export const ORG_NAME_URLPARAM = 'organization';
 export const LINK_NAME_URLPARAM = 'link';
 export const BASE_URL_PARAM = 'base';
-export const CATEGORY_URL_PARAM = 'category';
+export const CATEGORY_URL_PARAM = 'categoryId';
 export const PLACE_URL_PARAM = 'place';
 export const ORG_NAME_COOKIE = 'orgName';
 export const LINK_NAME_COOKIE = 'linkName';
 export const BASE_URL_COOKIE = 'baseName';
-export const CATEGORY_URL_COOKIE = 'categoryName';
+export const CATEGORY_URL_COOKIE = 'categoryId';
 export const PLACE_URL_COOKIE = 'placeName';

--- a/src/constants/defaults.js
+++ b/src/constants/defaults.js
@@ -1,5 +1,5 @@
 export const DEFAULT_ORG_NAME = 'bitsaber-staging';
 export const DEFAULT_LINK_NAME = 'staging-place-tarvikkeet';
 export const DEFAULT_BASE_API_URL = 'https://app-staging.incy.io/api';
-export const DEFAULT_CATEGORY_NAME = 'Equipment';
+export const DEFAULT_CATEGORY_ID = '65336';
 export const DEFAULT_PLACE_NAME = 'Staging Place';

--- a/src/service.js
+++ b/src/service.js
@@ -5,7 +5,7 @@ import {
     DEFAULT_ORG_NAME,
     DEFAULT_LINK_NAME,
     DEFAULT_BASE_API_URL,
-    DEFAULT_CATEGORY_NAME,
+    DEFAULT_CATEGORY_ID,
     DEFAULT_PLACE_NAME,
 } from './constants/defaults';
 
@@ -51,8 +51,8 @@ const linkName = getValueFromCookieUrlOrDefaultAndCache(
     LINK_NAME_COOKIE
 );
 
-const categoryName = getValueFromCookieUrlOrDefaultAndCache(
-    DEFAULT_CATEGORY_NAME,
+const categoryId = getValueFromCookieUrlOrDefaultAndCache(
+    DEFAULT_CATEGORY_ID,
     CATEGORY_URL_PARAM,
     CATEGORY_URL_COOKIE
 );
@@ -98,8 +98,8 @@ const getCategory = async (langId) => {
             "Accept-Language": (langId + ';q=1'),
         },
     });
-    const selectedCategory = categoryName;
-    const foundCategory = categories.find(category => category.name === selectedCategory);
+    const selectedCategoryId = categoryId;
+    const foundCategory = categories.find(category => category.id.toString() === selectedCategoryId);
     if (foundCategory) {
         return foundCategory;
     } else {


### PR DESCRIPTION
Because the name of the same category can be both `Equipment` and `Tarvikkeet` the logic does not work when setting the url parameter `category`. Therefore the url parameter had to be changed to `categoryId` and the id of the category has to be used